### PR TITLE
Fix: handle OboTokenError without logging full traceback

### DIFF
--- a/src/az_scout_plugin_batch_sku/routes.py
+++ b/src/az_scout_plugin_batch_sku/routes.py
@@ -50,6 +50,10 @@ async def list_batch_skus(
             "totalSkus": len(skus),
             "skus": skus,
         }
+
+    except OboTokenError:
+        raise
+
     except Exception as exc:
         logger.exception("Failed to fetch Batch SKUs")
         raise PluginUpstreamError(f"Failed to fetch Batch SKUs: {exc}") from exc


### PR DESCRIPTION
Fixes unnecessary traceback logging for OboTokenError.

- Catch OboTokenError separately and re-raise it so az-scout core can handle it
- Avoid logging full traceback for expected auth failures
- Keep logger.exception() only for unexpected errors

Closes #12 